### PR TITLE
Fix composer.json autoload psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,5 @@
         "psr-4": {
             "Seegno\\TestBundle\\": ""
         }
-    },
-    "target-dir": "Seegno/TestBundle"
+    }
 }


### PR DESCRIPTION
Removed `target_dir` to be compatible with autoload psr-4.